### PR TITLE
Update production stats based on research

### DIFF
--- a/scripts/parallel_research.lua
+++ b/scripts/parallel_research.lua
@@ -61,12 +61,14 @@ function execute_research(lab_data)
     end
 
     -- Give progress to the assigned technology and research it once it progress reaches 100%
-    local progress_gained = 1 * lab_data.speed * lab_data.productivity * storage.lab_count_multiplier * CHEAT_SPEED_MULTIPLIER * CHEAT_PRODUCTIVITY_MULTIPLIER / research_unit_count / research_unit_energy
+    local progress_gained = 1 * lab_data.speed * lab_data.productivity * storage.lab_count_multiplier * CHEAT_SPEED_MULTIPLIER * CHEAT_PRODUCTIVITY_MULTIPLIER  / research_unit_energy
+    local stats = game.forces["player"].get_item_production_statistics(entity.surface)
+    stats.on_flow("science", progress_gained)
     local new_progress
     if is_currently_researching then
-        new_progress = game.forces["player"].research_progress + progress_gained
+        new_progress = game.forces["player"].research_progress + progress_gained / research_unit_count
     else
-        new_progress = tech.saved_progress + progress_gained
+        new_progress = tech.saved_progress + progress_gained / research_unit_count
     end
     if new_progress >= 1 then
         -- Manually reset research progress because the game doesn't do it for us for infinite techs

--- a/scripts/process_research.lua
+++ b/scripts/process_research.lua
@@ -40,7 +40,9 @@ end
 function digitize_science_packs(item, lab_data)
     local durability = prototypes.item[item.name].get_durability(item.quality)
     local removed = lab_data.inventory.remove({name = item.name, quality = item.quality, count = DIGITIZED_AMOUNT})
+    local stats = lab_data.entity.force.get_item_production_statistics(lab_data.entity.surface)
     lab_data.digital_inventory[item.name] = lab_data.digital_inventory[item.name] + durability * removed
+    stats.on_flow({name = item.name, quality = item.quality}, -removed)
     return removed > 0
 end
 


### PR DESCRIPTION
This allows the player to track science units researched as well as science packs consumed rather than have all science-related stats vanish on the production graph. This also updates the tooltip for the technologies button, though the ETA it reports will be wrong due to expecting the produced science to all go towards the first technology in the queue.