### PR TITLE
Fix crash from trying to digitize spoilage

### DIFF
--- a/scripts/process_research.lua
+++ b/scripts/process_research.lua
@@ -99,7 +99,7 @@ function refresh_labs_inventory(labs_data)
         local surface_index = lab_data.entity.surface_index
         for i = 1, lab_data.inventory_size do
             local item = lab_data.inventory[i]
-            if item.valid and item.valid_for_read and item.name then
+            if item.valid and item.valid_for_read and item.name and item.is_tool then
                 ---@type LabPackStackData
                 local item_data = {
                     name = item.name,


### PR DESCRIPTION
In the unlikely event that an Agricultural science pack spoils, and then Parallel Research tries to digitise the contents of the lab before it's removed, it would previously attempt to access the `durability` property of the item stack, which causes a crash if the item in question is not a tool.

Fixes https://mods.factorio.com/mod/simultaneous-research/discussion/68429213f61a136e1ef7269e