### PR TITLE
Changed labs-per-second-processed value to configurable value defaulting to 600. 

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -21,6 +21,10 @@ custom-status-low-temperature=Low temperature
 
 [mod-setting-name]
 sr-research-mode=Parallel research mode
+sr-labs-per-second-processed=Labs per second processed
+
+[mod-setting-description]
+sr-labs-per-second-processed=Number of labs processed per second. Higher values cause labs to generate science more frequently without changing the overall output, at the cost of performance. Reduce this value if you experience performance issues.
 
 [string-mod-setting]
 sr-research-mode-parallel=All in a queue

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -24,7 +24,7 @@ sr-research-mode=Parallel research mode
 sr-labs-per-second-processed=Labs per second processed
 
 [mod-setting-description]
-sr-labs-per-second-processed=Number of labs processed per second. Higher values cause labs to generate science more frequently without changing the overall output, at the cost of performance. Reduce this value if you experience performance issues.
+sr-labs-per-second-processed=High values increase processing accuracy at the cost of performance.\nRecommended to set it to at least 1/10 of your total number of labs to avoid potential issues.
 
 [string-mod-setting]
 sr-research-mode-parallel=All in a queue

--- a/scripts/constants.lua
+++ b/scripts/constants.lua
@@ -1,9 +1,17 @@
-LABS_PER_SECOND_PROCESSED = 6 --Should be a clean divisor of 60 or it would be less accurate
+LABS_PER_SECOND_PROCESSED = settings.startup["sr-labs-per-second-processed"].value --Should be a clean divisor or multiple of 60 or it would be less accurate
+
+if LABS_PER_SECOND_PROCESSED <= 60 then --When LABS_PER_SECOND_PROCESSED > 60, multiple labs will be processed per tick, else, only one.
+    LABS_PER_TICK_PROCESSED = 1
+else
+    LABS_PER_TICK_PROCESSED = math.ceil(LABS_PER_SECOND_PROCESSED/60)
+end
+
+
 
 NTH_TICK = {
     new_lab_recheck = 294, -- How often we are going to recheck for new labs
     lab_update = 58, -- How often we update labs with their current speed/productivity (1 lab at a time)
-    lab_processing = math.ceil(60 / LABS_PER_SECOND_PROCESSED),
+    lab_processing = math.max(1,math.ceil(60 / LABS_PER_SECOND_PROCESSED)),
 }
 
 -- Debug multipliers

--- a/scripts/parallel_research.lua
+++ b/scripts/parallel_research.lua
@@ -6,13 +6,15 @@ local lab_utils = require("scripts/lab_utils")
 ---Updates one lab at a time.
 function update_research()
     if storage.mod_enabled then
-        if next(storage.labs) then
-            ::again::
-            storage.labs_index = flib_table.for_n_of(storage.labs, storage.labs_index, 1, function(lab_data)
-                return execute_research(lab_data)
-            end)
-            -- We need to do this to eliminate an empty update that happens at the end of every loop for some reason
-            if storage.labs_index == nil then goto again end
+        for i = 1,LABS_PER_TICK_PROCESSED do
+            if next(storage.labs) then
+                ::again::
+                storage.labs_index = flib_table.for_n_of(storage.labs, storage.labs_index, 1, function(lab_data)
+                    return execute_research(lab_data)
+                end)
+                -- We need to do this to eliminate an empty update that happens at the end of every loop for some reason
+                if storage.labs_index == nil then goto again end
+            end
         end
     end
 end

--- a/settings.lua
+++ b/settings.lua
@@ -7,5 +7,27 @@ data:extend(
         setting_type = "runtime-global",
         default_value = "parallel",
         allowed_values = {"parallel", "smart"},
-    }
+    },
+    {
+        type = "double-setting",
+        order = "aa",
+        name = "sr-labs-per-second-processed", 
+        setting_type = "startup",
+        default_value = 600,
+        allowed_values = {1,2,3,4,5,6,10,12,15,20,30,60,120,180,240,300,360,600,1200,1800,2400}, --Should be a clean divisor or multiple of 60 or it would be less accurate
+    },
+    -- {
+    --     type = "double-setting",
+    --     order = "aa",
+    --     name = "sr-lab-update",
+    --     setting_type = "startup",
+    --     default_value = 58,
+    -- },
+    -- {
+    --     type = "double-setting",
+    --     order = "aa",
+    --     name = "sr-new-lab-recheck",
+    --     setting_type = "startup",
+    --     default_value = 294,
+    -- }
 })

--- a/settings.lua
+++ b/settings.lua
@@ -13,7 +13,7 @@ data:extend(
         order = "aa",
         name = "sr-labs-per-second-processed", 
         setting_type = "startup",
-        default_value = 600,
+        default_value = 12,
         allowed_values = {1,2,3,4,5,6,10,12,15,20,30,60,120,180,240,300,360,600,1200,1800,2400}, --Should be a clean divisor or multiple of 60 or it would be less accurate
     },
     -- {


### PR DESCRIPTION
This PR changes the labs-per-second-processed value to a startup-configurable value, which can be set to any divisor or multiple of 60. When this value is greater than 60, multiple labs will be processed every tick. On my computer, setting the labs-per-second to 600 causes the script to consume 0.5-1.0 ms per update. I think this value is low enough to work on most computers, but if you disagree, you're welcome to change the default to something lower.
![image](https://github.com/user-attachments/assets/88626506-a6b4-4aa2-a3b3-6a1fc2cb30bf)
![image](https://github.com/user-attachments/assets/8d0de6f7-9e27-4998-9b5e-96d4c8153876)
![image](https://github.com/user-attachments/assets/38efd291-abec-44d9-a366-75323de7cda9)
